### PR TITLE
feat(repo): Add merge command, change consume command behaviour

### DIFF
--- a/src/satellite_consumer/cmd/main.py
+++ b/src/satellite_consumer/cmd/main.py
@@ -13,8 +13,8 @@ from satellite_consumer.config import (
     ArchiveCommandOptions,
     Command,
     ConsumeCommandOptions,
-    SatelliteConsumerConfig,
     MergeCommandOptions,
+    SatelliteConsumerConfig,
 )
 from satellite_consumer.run import run
 

--- a/src/satellite_consumer/cmd/main.py
+++ b/src/satellite_consumer/cmd/main.py
@@ -14,6 +14,7 @@ from satellite_consumer.config import (
     Command,
     ConsumeCommandOptions,
     SatelliteConsumerConfig,
+    MergeCommandOptions,
 )
 from satellite_consumer.run import run
 
@@ -55,34 +56,57 @@ def cli_entrypoint() -> None:
     consume_parser.add_argument("--eumetsat-key", type=str, required=True)
     consume_parser.add_argument("--eumetsat-secret", type=str, required=True)
 
+    merge_parser = subparsers.add_parser("merge",
+        help="Merge satellite data for a given window",
+    )
+    merge_parser.add_argument("satellite", choices=list(SATELLITE_METADATA.keys()))
+    merge_parser.add_argument("--window-mins",
+        type=int, help="Merge window size in minutes", default=210,
+    )
+    merge_parser.add_argument("--window-end", "-t",
+        type=dt.datetime.fromisoformat,
+        help="End of merge window (YYYY-MM-DDTHH:MM:SS)",
+    )
+    merge_parser.add_argument("--workdir", type=str, default="/mnt/disks/sat")
+    merge_parser.add_argument("--hrv", action="store_true")
+
     args = parser.parse_args()
 
     os.environ["EUMETSAT_CONSUMER_KEY"] = args.eumetsat_key
     os.environ["EUMETSAT_CONSUMER_SECRET"] = args.eumetsat_secret
 
-    command_opts: ArchiveCommandOptions | ConsumeCommandOptions
-    command = Command(args.command)
-    if command == "archive":
-        command_opts = ArchiveCommandOptions(
-            satellite=args.satellite,
-            month=args.month,
-            delete_raw=args.delete_raw,
-            validate=args.validate,
-            hrv=args.hrv,
-            rescale=args.rescale,
-            workdir=args.workdir,
-        )
-    else:
-        command_opts = ConsumeCommandOptions(
-            satellite=args.satellite,
-            time=args.time,
-            delete_raw=args.delete_raw,
-            validate=args.validate,
-            hrv=args.hrv,
-            rescale=args.rescale,
-            workdir=args.workdir,
-            latest_zip=args.zip,
-        )
+    command_opts: ArchiveCommandOptions | ConsumeCommandOptions | MergeCommandOptions
+    command = Command(args.command.upper())
+    match command:
+        case Command.ARCHIVE:
+            command_opts = ArchiveCommandOptions(
+                satellite=args.satellite,
+                month=args.month,
+                delete_raw=args.delete_raw,
+                validate=args.validate,
+                hrv=args.hrv,
+                rescale=args.rescale,
+                workdir=args.workdir,
+            )
+        case Command.CONSUME:
+            command_opts = ConsumeCommandOptions(
+                satellite=args.satellite,
+                time=args.time,
+                delete_raw=args.delete_raw,
+                validate=args.validate,
+                hrv=args.hrv,
+                rescale=args.rescale,
+                workdir=args.workdir,
+            )
+        case Command.MERGE:
+            command_opts = MergeCommandOptions(
+                satellite=args.satellite,
+                window_mins=args.window_mins,
+                window_end=args.window_end,
+                hrv=args.hrv,
+                workdir=args.workdir,
+            )
+
     config: SatelliteConsumerConfig = SatelliteConsumerConfig(
         command=command, command_options=command_opts,
     )
@@ -99,34 +123,53 @@ def env_entrypoint() -> None:
     """Handle the program using environment variables."""
     try:
         command = Command(os.environ["SATCONS_COMMAND"])
-        command_opts: ArchiveCommandOptions | ConsumeCommandOptions
-        if command == "archive":
-            command_opts = ArchiveCommandOptions(
-                satellite=os.environ["SATCONS_SATELLITE"],
-                month=os.environ["SATCONS_MONTH"],
-                delete_raw=os.getenv("SATCONS_DELETE_RAW", "false") == "true",
-                validate=os.getenv("SATCONS_VALIDATE", "false") == "true",
-                hrv=os.getenv("SATCONS_HRV", "false") == "true",
-                rescale=os.getenv("SATCONS_RESCALE", "false") == "true",
-                workdir=os.getenv("SATCONS_WORKDIR", "/mnt/disks/sat"),
-                num_workers=int(os.getenv("SATCONS_NUM_WORKERS", default="1")),
-            )
-        else:
-            if os.getenv("SATCONS_TIME") is None:
-                t: dt.datetime | None = None
-            else:
-                t = dt.datetime.fromisoformat(os.environ["SATCONS_TIME"])
-            command_opts = ConsumeCommandOptions(
-                satellite=os.environ["SATCONS_SATELLITE"],
-                time=t,
-                delete_raw=os.getenv("SATCONS_DELETE_RAW", "false") == "true",
-                validate=os.getenv("SATCONS_VALIDATE", "false") == "true",
-                hrv=os.getenv("SATCONS_HRV", "false") == "true",
-                rescale=os.getenv("SATCONS_RESCALE", "false") == "true",
-                workdir=os.getenv("SATCONS_WORKDIR", "/mnt/disks/sat"),
-                num_workers=int(os.getenv("SATCONS_NUM_WORKERS", default="1")),
-                latest_zip=os.getenv("SATCONS_ZIP", "false") == "true",
-            )
+        command_opts: ArchiveCommandOptions | ConsumeCommandOptions | MergeCommandOptions
+        match command:
+            case Command.ARCHIVE:
+                command_opts = ArchiveCommandOptions(
+                    satellite=os.environ["SATCONS_SATELLITE"],
+                    month=os.environ["SATCONS_MONTH"],
+                    delete_raw=os.getenv("SATCONS_DELETE_RAW", "false") == "true",
+                    validate=os.getenv("SATCONS_VALIDATE", "false") == "true",
+                    hrv=os.getenv("SATCONS_HRV", "false") == "true",
+                    rescale=os.getenv("SATCONS_RESCALE", "false") == "true",
+                    workdir=os.getenv("SATCONS_WORKDIR", "/mnt/disks/sat"),
+                    num_workers=int(os.getenv("SATCONS_NUM_WORKERS", default="1")),
+                )
+            case Command.CONSUME:
+                if os.getenv("SATCONS_TIME") is None:
+                    t: dt.datetime | None = None
+                else:
+                    t = dt.datetime.fromisoformat(os.environ["SATCONS_TIME"])
+
+                command_opts = ConsumeCommandOptions(
+                    satellite=os.environ["SATCONS_SATELLITE"],
+                    time=t,
+                    delete_raw=os.getenv("SATCONS_DELETE_RAW", "false") == "true",
+                    validate=os.getenv("SATCONS_VALIDATE", "false") == "true",
+                    hrv=os.getenv("SATCONS_HRV", "false") == "true",
+                    rescale=os.getenv("SATCONS_RESCALE", "false") == "true",
+                    workdir=os.getenv("SATCONS_WORKDIR", "/mnt/disks/sat"),
+                    num_workers=int(os.getenv("SATCONS_NUM_WORKERS", default="1")),
+                )
+            case Command.MERGE:
+                # Use SATCONS_TIME if SATCONS_WINDOW_END is not set
+                if os.getenv("SATCONS_WINDOW_END") is None:
+                    if os.getenv("SATCONS_TIME") is None:
+                        window_end: dt.datetime | None = None
+                    else:
+                        window_end = dt.datetime.fromisoformat(os.environ["SATCONS_TIME"])
+                else:
+                    window_end = dt.datetime.fromisoformat(os.environ["SATCONS_TIME"])
+
+                command_opts = MergeCommandOptions(
+                    satellite=os.environ["SATCONS_SATELLITE"],
+                    window_mins=int(os.getenv("SATCONS_WINDOW_MINS", default="210")),
+                    window_end=window_end,
+                    hrv=os.getenv("SATCONS_HRV", "false") == "true",
+                    workdir=os.getenv("SATCONS_WORKDIR", "/mnt/disks/sat"),
+                )
+
     except KeyError as e:
         log.error(f"Missing environment variable: {e}")
         return

--- a/src/satellite_consumer/config.py
+++ b/src/satellite_consumer/config.py
@@ -203,7 +203,9 @@ class ConsumeCommandOptions:
     def time_window(self) -> tuple[dt.datetime, dt.datetime]:
         """Get the time window for the given time."""
         # Round the start time down to the nearest interval given by the channel cadence
-        start: dt.datetime = (self.time - pd.DateOffset(minutes=self.satellite_metadata.cadence_mins)) # type:ignore
+        start: dt.datetime = (
+            self.time - pd.DateOffset(minutes=self.satellite_metadata.cadence_mins) # type: ignore
+        )
         return start, self.time # type:ignore  # safe due to post_init
 
     @property

--- a/src/satellite_consumer/config.py
+++ b/src/satellite_consumer/config.py
@@ -280,6 +280,7 @@ class MergeCommandOptions:
             for ts in pd.date_range(
                 start=self.time_window[0], end=self.time_window[1],
                 freq=f"{SATELLITE_METADATA[self.satellite].cadence_mins}min",
+                inclusive="right",
             )
         ]
 

--- a/src/satellite_consumer/config.py
+++ b/src/satellite_consumer/config.py
@@ -17,8 +17,8 @@ class Coordinates:
     """
 
     time: list[np.datetime64]
-    x_geostationary: list[float]
     y_geostationary: list[float]
+    x_geostationary: list[float]
     variable: list[str]
 
     def to_dict(self) -> dict[str, list[float] | list[str] | list[np.datetime64]]:
@@ -68,8 +68,9 @@ class Coordinates:
 class Command(StrEnum):
     """The available commands for the satellite consumer."""
 
-    archive = auto()
-    consume = auto()
+    ARCHIVE = auto()
+    CONSUME = auto()
+    MERGE = auto()
 
 @dataclasses.dataclass
 class ArchiveCommandOptions:
@@ -152,7 +153,7 @@ class ConsumeCommandOptions:
     satellite: str
     """The satellite to consume data from."""
     time: dt.datetime | None = None
-    """The time to download data for. Pulls 3.5 hours of data up to this time."""
+    """The time to download data for."""
     delete_raw: bool = False
     """Whether to delete the raw data after downloading it."""
     validate: bool = False
@@ -166,8 +167,6 @@ class ConsumeCommandOptions:
 
     Can be either a local path or an S3 path (s3://bucket-name/path).
     """
-    latest_zip: bool = False
-    """Whether to zip the zarr store into a latest.zarr.zip after creating it."""
     num_workers: int = 1
     """The number of workers to use for downloading and processing the data."""
 
@@ -204,7 +203,7 @@ class ConsumeCommandOptions:
     def time_window(self) -> tuple[dt.datetime, dt.datetime]:
         """Get the time window for the given time."""
         # Round the start time down to the nearest interval given by the channel cadence
-        start: dt.datetime = (self.time - pd.DateOffset(hours=3, minutes=30)) # type:ignore
+        start: dt.datetime = (self.time - pd.DateOffset(minutes=self.satellite_metadata.cadence_mins)) # type:ignore
         return start, self.time # type:ignore  # safe due to post_init
 
     @property
@@ -231,6 +230,62 @@ class ConsumeCommandOptions:
             variable=[ch.name for ch in SEVIRI_CHANNELS if ch.is_high_res == self.hrv],
         )
 
+@dataclasses.dataclass
+class MergeCommandOptions:
+    """Options for the merge command."""
+
+    satellite: str
+    """The satellite to merge data for."""
+    window_mins: int = 210
+    """The time window of consumed data to merge."""
+    window_end: dt.datetime | None = None
+    """The end time of the time window to merge data for."""
+    workdir: str = "/mnt/disks/sat"
+    """The parent folder to store downloaded and processed data in.
+
+    Can be either a local path or an S3 path (s3://bucket-name/path).
+    """
+    hrv: bool = False
+    """Whether to merge the high resolution channel data (defaults to low res)."""
+
+    def __post_init__(self) -> None:
+        """Perform some validation on the input data."""
+        if self.satellite not in SATELLITE_METADATA:
+            raise ValueError(
+                f"Invalid satellite '{self.satellite}'. Must be one of {SATELLITE_METADATA.keys()}",
+            )
+        if self.window_mins <= 0:
+            raise ValueError("Window size must be positive.")
+        if self.window_end is not None:
+            if self.window_end.replace(tzinfo=dt.UTC) > dt.datetime.now(tz=dt.UTC):
+                raise ValueError("Window end must be in the past.")
+        else:
+            self.window_end = dt.datetime.now(tz=dt.UTC)
+
+    @property
+    def time_window(self) -> tuple[dt.datetime, dt.datetime]:
+        """Get the time window for the given window end and size."""
+        end: dt.datetime = self.window_end # type: ignore
+        start: dt.datetime = end - pd.DateOffset(minutes=self.window_mins)
+        return start, end
+
+    @property
+    def zarr_paths(self) -> list[str]:
+        """Get the path to the zarr stores for the given time window."""
+        resstr: str = "hrv" if self.hrv else "nonhrv"
+        return [
+            f"{self.workdir}/data/{ts.strftime('%Y%m%dT%H%M')}_{resstr}.zarr"
+            for ts in pd.date_range(
+                start=self.time_window[0], end=self.time_window[1],
+                freq=f"{SATELLITE_METADATA[self.satellite].cadence_mins}min",
+            )
+        ]
+
+    @property
+    def merged_path(self) -> str:
+        """Get the path to the merged zarr store for the given time window."""
+        return f"{self.workdir}/data/latest.zarr.zip"
+
 
 @dataclasses.dataclass
 class SatelliteConsumerConfig:
@@ -238,7 +293,7 @@ class SatelliteConsumerConfig:
 
     command: Command
     """The operational mode of the consumer."""
-    command_options:  ArchiveCommandOptions | ConsumeCommandOptions
+    command_options:  ArchiveCommandOptions | ConsumeCommandOptions | MergeCommandOptions
     """Options for the chosen command."""
 
 

--- a/src/satellite_consumer/process.py
+++ b/src/satellite_consumer/process.py
@@ -120,7 +120,7 @@ def _map_scene_to_dataarray(
             scene.attrs[f"{channel['name']}_{attr}"] = scene[channel].attrs[attr].__repr__()
 
     da: xr.DataArray = scene.to_xarray_dataset().to_array().rename("data")
-    da.attrs.update(scene.attrs)
+    da.attrs = da.attrs | scene.attrs
 
     # Ensure DataArray has a time dimension
     da.attrs["end_time"] = pd.Timestamp(da.attrs["end_time"]).round("5 min").__str__()

--- a/src/satellite_consumer/run.py
+++ b/src/satellite_consumer/run.py
@@ -100,6 +100,7 @@ def _consume_command(command_opts: ArchiveCommandOptions | ConsumeCommandOptions
 def _merge_command(command_opts: MergeCommandOptions) -> None:
     """Logic for the merge command."""
     zarr_paths = command_opts.zarr_paths
+    log.info(f"Merging {len(zarr_paths)} stores", num=len(zarr_paths))
     fs = get_fs(path=zarr_paths[0])
 
     for zarr_path in zarr_paths:
@@ -119,10 +120,12 @@ def run(config: SatelliteConsumerConfig) -> None:
         version=__version__, start_time=str(prog_start), opts=config.command_options.__str__(),
     )
 
-    if (config.command == "archive" or config.command == "consume"):
+    if isinstance(config.command_options, ArchiveCommandOptions | ConsumeCommandOptions):
         _consume_command(command_opts=config.command_options)
-    elif config.command == "merge" and isinstance(config.command_options, MergeCommandOptions):
+    elif isinstance(config.command_options, MergeCommandOptions):
         _merge_command(command_opts=config.command_options)
+    else:
+        pass
 
     runtime = dt.datetime.now(tz=dt.UTC) - prog_start
     log.info(f"Completed satellite consumer run in {runtime!s}.")

--- a/src/satellite_consumer/run.py
+++ b/src/satellite_consumer/run.py
@@ -13,8 +13,8 @@ from loguru import logger as log
 from satellite_consumer.config import (
     ArchiveCommandOptions,
     ConsumeCommandOptions,
-    SatelliteConsumerConfig,
     MergeCommandOptions,
+    SatelliteConsumerConfig,
 )
 from satellite_consumer.download_eumetsat import (
     download_nat,

--- a/src/satellite_consumer/test_storage.py
+++ b/src/satellite_consumer/test_storage.py
@@ -83,7 +83,7 @@ class TestStorage(unittest.TestCase):
                     )
                     self.assertListEqual(
                         list(store_da.dims),
-                        ["time", "x_geostationary", "y_geostationary", "variable"],
+                        ["time", "y_geostationary", "x_geostationary", "variable"],
                         msg="Dimension ordering of emtpy store is incorrect",
                     )
                     for coord in list(coords.to_dict().keys()):


### PR DESCRIPTION
Makes the consume command download only a single scan at a time, instead of three hours at a time, to work better with the deployment setup we use in production. "Latest" 3 hourly combined stores are made with the new merge command. This should be much faster and more efficient for our live processes. 