### PR TITLE
fix(storage): Don't use temp storage for zip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Each command then has its own set of configuration options:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SATCONS_SATELLITE` | | The satellite to consume data from. |
-| `SATCONS_WINDOW_MINS` | | The time window to merge data for. |
+| `SATCONS_WINDOW_MINS` | `210` | The time window to merge data for. |
 | `SATCONS_CONSUME_MISSING` | `false` | Whether to consume missing data. |
 
 ## FAQ

--- a/src/satellite_consumer/run.py
+++ b/src/satellite_consumer/run.py
@@ -122,7 +122,7 @@ def _merge_command(command_opts: MergeCommandOptions) -> None:
             else:
                 raise FileNotFoundError(f"Zarr store not found at {zarr_path}")
 
-    dst = create_latest_zip(dsts=zarr_paths)
+    dst = create_latest_zip(srcs=zarr_paths)
     log.info("Created latest.zip", dst=dst)
 
 

--- a/src/satellite_consumer/storage.py
+++ b/src/satellite_consumer/storage.py
@@ -3,7 +3,6 @@
 
 import datetime as dt
 import os
-import tempfile
 
 import fsspec
 import numpy as np


### PR DESCRIPTION
Prevent use of temp storage for zip files, which might be slowing down writing on AWS