### PR TITLE
fix(merge): Correct merge time window, remove warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: test lint typecheck
+
+test:
+	uv run python -m unittest discover -s tests -p "test_*.py"
+
+test-cov:
+	uv run python -m xmlrunner discover -s tests -p "test_*.py"
+
+lint:
+	uv run ruff check --fix .
+
+typecheck:
+	uv run mypy .
+

--- a/README.md
+++ b/README.md
@@ -23,9 +23,18 @@ this consumer processes downloaded data into the `Zarr` format.
 ## Installation
 
 Install using the container image:
+
 ```bash
 $ docker pull ghcr.io/openclimatefix/satellite-consumer
 ```
+
+or, if you prefer a CLI:
+
+```bash
+$ pip install git+https://github.com/openclimatefix/satellite-consumer.git
+```
+
+This will put the `sat-consumer-cli` command in your virtual environments `bin` directory.
 
 ## Example usage
 
@@ -39,6 +48,7 @@ $ docker run \
     ghcr.io/openclimatefix/satellite-consumer
 ```
 
+This will download the latest available data for the `rss` satellite and store it in the `/work` directory.
 For a description of all the possible configuration options, see [Documentation](#documentation).
 
 ## Documentation
@@ -47,10 +57,15 @@ The satellite consumer provides a number of commands for different logical proce
 These commands (and their options) can be seen when using the cli entrypoint:
 
 ```bash
-$ satellite-consumer-cli --help
+$ sat-consumer-cli --help
 ```
 
-When running the satellite consumer using the environment entrypoint (as in the docker container),
+When running the satellite consumer using the environment entrypoint (as in the docker container)
+
+```bash
+$ sat-consumer
+```
+
 the command is chosen via an environment variable. There are also a number of common configuration
 options that are shared between all commands:
 
@@ -100,12 +115,20 @@ Each command then has its own set of configuration options:
 
 ### How do I add a new satellite to the consumer?
 
-Current;y the consumer is built to the specific data requirements of Open Climate Fix.
+Currently the consumer is built to the specific data requirements of Open Climate Fix.
 However, adding a new satellite in the from EUMETSAT shouldn't be too hard, provided it uses
 the same `seviri_l1b_native` format and sensor channels - just update the available satellites
 in `config.py`.
 
 ## Development
+
+OCF recommends using [uv](https://docs.astral.sh/uv/) for managing your virtual environments.
+
+```bash
+$ git clone git@github.com:openclimatefix/satellite-consumer.git
+$ cd satellite-consumer
+$ uv sync
+```
 
 ### Running the CLI
 
@@ -133,14 +156,19 @@ but it prevents accidental creation of a whole suite of bugs.
 ### Running the test suite
 
 There are some additional dependencies to be installed for running the tests,
-be sure to pass `--extra=dev` to the `pip install -e .` command when creating your virtualenv.
-(Or use uv and let it do it for you!)
+be sure to pass `--extra=dev` to the `pip install -e .` command when creating your virtualenv
+(`uv sync` includes the development dependencies by default, so `uv` users can ignore this!).
 
 Run the unit tests with:
 
 ```bash
-$ python -m unittest discover -s src/nwp_consumer -p "test_*.py"
+$ python -m unittest discover -s src/satellite_consumer -p "test_*.py"
 ```
+
+> [!Note]
+> If you have created your virtual environment using `uv`, the above can be run via
+> the `Makefile`, using `make typecheck`, `make lint`, and `make test` respectively.
+
  
 ## Further reading
 

--- a/src/satellite_consumer/config.py
+++ b/src/satellite_consumer/config.py
@@ -280,7 +280,8 @@ class MergeCommandOptions:
         else:
             self.window_end = dt.datetime.now(tz=dt.UTC)
 
-        if self.window_end.minute % self.satellite_metadata.cadence_mins != 0 or self.window_end.second != 0:
+        if self.window_end.minute % self.satellite_metadata.cadence_mins != 0 \
+                or self.window_end.second != 0:
             newtime: dt.datetime = (self.window_end - dt.timedelta(
                 minutes=self.window_end.minute % self.satellite_metadata.cadence_mins,
             )).replace(second=0, microsecond=0)

--- a/src/satellite_consumer/config.py
+++ b/src/satellite_consumer/config.py
@@ -280,6 +280,23 @@ class MergeCommandOptions:
         else:
             self.window_end = dt.datetime.now(tz=dt.UTC)
 
+        if self.window_end.minute % self.satellite_metadata.cadence_mins != 0 or self.window_end.second != 0:
+            newtime: dt.datetime = (self.window_end - dt.timedelta(
+                minutes=self.window_end.minute % self.satellite_metadata.cadence_mins,
+            )).replace(second=0, microsecond=0)
+            log.debug(
+                "Input window end is not a multiple of the chosen satellite's image cadence. " + \
+                "Adjusting to nearest image time.",
+                input_window_end=str(self.window_end),
+                adjusted_time=str(newtime),
+            )
+            self.window_end = newtime
+
+    @property
+    def satellite_metadata(self) -> "SatelliteMetadata":
+        """Get the metadata for the chosen satellite."""
+        return SATELLITE_METADATA[self.satellite]
+
     @property
     def time_window(self) -> tuple[dt.datetime, dt.datetime]:
         """Get the time window for the given window end and size."""

--- a/src/satellite_consumer/storage.py
+++ b/src/satellite_consumer/storage.py
@@ -146,7 +146,8 @@ def create_empty_zarr(dst: str, coords: Coordinates) -> xr.DataArray:
     # TODO: Remove this when Zarr makes up its mind on string codecs
     with warnings.catch_warnings(action="ignore"):
         var_zarray = group.create_array(
-            name="variable", dimension_names=["variable"], shape=(len(coords.variable),), dtype="str",
+            name="variable", dimension_names=["variable"],
+            shape=(len(coords.variable),), dtype="str",
         )
         var_zarray[:] = coords.variable
 

--- a/src/satellite_consumer/validate.py
+++ b/src/satellite_consumer/validate.py
@@ -1,9 +1,10 @@
 """Functions for validating the quality of the data in a dataset."""
 
+import warnings
+
 import numpy as np
 import xarray as xr
 from loguru import logger as log
-import warnings
 
 from satellite_consumer.exceptions import ValidationError
 

--- a/src/satellite_consumer/validate.py
+++ b/src/satellite_consumer/validate.py
@@ -3,6 +3,7 @@
 import numpy as np
 import xarray as xr
 from loguru import logger as log
+import warnings
 
 from satellite_consumer.exceptions import ValidationError
 
@@ -42,7 +43,9 @@ def validate(
             return 1.0
         return float(nulls.sum() / len(nulls))
 
-    da = xr.open_dataarray(src, engine="zarr", consolidated=False)
+    # TODO: Remove warnings catch when Zarr makes up its mind about codecs
+    with warnings.catch_warnings(action="ignore"):
+        da = xr.open_dataarray(src, engine="zarr", consolidated=False)
     if not {"x_geostationary", "y_geostationary"}.issubset(set(da.dims)):
         raise ValidationError(
             "Cannot validate dataset at path {src}. "


### PR DESCRIPTION
Merge with consume missing was pulling values out of cadence with the time window. This resolves that, and cleans up the logging at the same time.