### PR TITLE
Fix command line failing on enum

### DIFF
--- a/src/satellite_consumer/cmd/main.py
+++ b/src/satellite_consumer/cmd/main.py
@@ -83,7 +83,7 @@ def cli_entrypoint() -> None:
     os.environ["EUMETSAT_CONSUMER_SECRET"] = args.eumetsat_secret
 
     command_opts: ConsumeCommandOptions | ExtractLatestCommandOptions
-    command = Command(args.command.upper())
+    command = Command(args.command.lower())
     match command:
         case Command.CONSUME:
             command_opts = ConsumeCommandOptions(


### PR DESCRIPTION
# Pull Request

## Description

This fixes #41 as it seems the Command enum expects lowercase, not upper-case arguments

Fixes #41

## How Has This Been Tested?

I ran the command in #41 and it works now

- [x] Yes


## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
