### PR TITLE
Fix Not Valid NetCDF4 file error for MTG

### DIFF
--- a/src/satellite_consumer/process.py
+++ b/src/satellite_consumer/process.py
@@ -79,7 +79,7 @@ def process_raw(
     del da["crs"]
     da = da.transpose("time", "y_geostationary", "x_geostationary", "variable")
     da = da.astype(np.float32)
-
+    da = da.load()
     return da
 
 


### PR DESCRIPTION
# Pull Request

## Description

This seems like it has to do with the files being closed after reading MTG files. Loading the data into memory then fixes that, otherwise the NetCDF file gets closed and the error occurs.

Fixes #

## How Has This Been Tested?

Running it locally to process MTG file data.

- [x] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
