### PR TITLE
More efficient satpy usage

### DIFF
--- a/src/satellite_consumer/process.py
+++ b/src/satellite_consumer/process.py
@@ -186,6 +186,9 @@ def stack_channels_to_dim(ds: xr.Dataset, channels: list[models.SpectralChannel]
         .sel(channel=[c.name for c in channels])
     )
 
+    # Replace the attrs with the compiled version
+    ds.attrs = attrs
+
     return ds
 
 


### PR DESCRIPTION
# Pull Request

## Description

This speeds up some of the processing done using satpy. In the previous implementation, we were creating xarray objects of the different bands multiple times (including just to extract the metadata from them). We were also accidentally silently loading the HRV at one point. In this implementation, we only create these objects once and load the data from disk once