### PR TITLE
Speed up nan-frac calculation

### DIFF
--- a/src/satellite_consumer/process.py
+++ b/src/satellite_consumer/process.py
@@ -228,4 +228,4 @@ def get_earthdisk_nan_frac(ds: xr.Dataset, chunksize: int = 500) -> float:
     channel_nan_fracs = [
         ds_nan.data_vars[var].values[on_earth_mask].mean() for var in ds_nan.data_vars
     ]
-    return np.mean(channel_nan_fracs).item()
+    return float(np.mean(channel_nan_fracs))


### PR DESCRIPTION
# Pull Request

## Description

This speeds up the nan-fraction calculation by using chunking (add using dask behind the scenes to parallelise the lon-lat calculation) and by avoiding using some slow xarray operations

My local testing showed this to speed up the nan check from 2.9s to 0.3s
