### PR TITLE
docs: improve README clarity and add Windows notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ or, if you prefer a CLI:
 $ pip install git+https://github.com/openclimatefix/satellite-consumer.git
 ```
 
-This will put the `sat-consumer-cli` command in your virtual environments `bin` directory.
+This will put the `sat-consumer-cli` command in your virtual environment's `bin` directory.
 
 ## Example usage
 
@@ -113,7 +113,7 @@ Each command then has its own set of configuration options:
 ### How do I add a new satellite to the consumer?
 
 Currently the consumer is built to the specific data requirements of Open Climate Fix.
-However, adding a new satellite in the from EUMETSAT shouldn't be too hard, provided it uses
+However, adding a new satellite from EUMETSAT shouldn't be too hard, provided it uses
 the same `seviri_l1b_native` format and sensor channels - just update the available satellites
 in `config.py`.
 
@@ -145,6 +145,11 @@ Use them via:
 $ python -m mypy .
 $ python -m ruff check .
 ```
+> [!NOTE]
+> **Windows users**: The `make` commands mentioned below require GNU Make, which is not available
+> by default on Windows. If you're on Windows, use the Python commands above directly instead
+> of the `make` commands.
+
 
 Be sure to do this periodically while developing to catch any errors early
 and prevent headaches with the CI pipeline. It may seem like a hassle at first,
@@ -163,8 +168,8 @@ $ python -m unittest discover -s src/satellite_consumer -p "test_*.py"
 ```
 
 > [!Note]
-> If you have created your virtual environment using `uv`, the above can be run via
-> the `Makefile`, using `make typecheck`, `make lint`, and `make test` respectively.
+> If you have created your virtual environment using `uv` **and have GNU Make installed**,
+> you can use the convenience commands: `make typecheck`, `make lint`, and `make test`.
 
  
 ## Further reading


### PR DESCRIPTION
## Description

This PR improves the README documentation with minor typo fixes and adds Windows-specific guidance for developers.

**Changes made:**
- Fixed grammatical error: `virtual environments` → `virtual environment's` (line 23)
- Removed duplicate word: `in the from EUMETSAT` → `from EUMETSAT` (line 111)
- Added Windows compatibility note explaining that `make` commands require GNU Make
- Clarified the relationship between `uv` and `make` in the development notes

**Motivation:**
As a Windows user setting up this project, I found that the `make` commands failed without explanation. These documentation improvements will help future Windows contributors get started more easily and reduce setup friction.

Fixes # (No issue - documentation improvement)

## How Has This Been Tested?

- [x] Yes

**Testing performed:**
- Verified README renders correctly in VS Code markdown preview
- Checked that all markdown formatting is correct (alerts, code blocks, tables)
- Confirmed no broken links or formatting issues introduced
- Validated that the Windows note appears in the correct location

_N/A - This PR only modifies documentation, no data processing changes._

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works _(N/A - documentation only)_
- [x] I have checked my code and corrected any misspellings