### PR TITLE
feat: Implement sliding window pipeline for concurrent downloading and processing

### DIFF
--- a/src/satellite_consumer/cmd/main.py
+++ b/src/satellite_consumer/cmd/main.py
@@ -1,5 +1,6 @@
 """Entrypoint to the satellite consumer."""
 
+import asyncio
 import datetime as dt
 import importlib.metadata
 import importlib.resources
@@ -74,7 +75,7 @@ def main() -> None:
         dt_range[1].isoformat(),
     )
 
-    consume.consume_to_store(
+    asyncio.run(consume.consume_to_store(
         dt_range=dt_range,
         cadence_mins=conf.get_int(f"satellites.{sat}.cadence_mins"),
         product_id=conf.get_string(f"satellites.{sat}.product_id"),
@@ -103,7 +104,8 @@ def main() -> None:
             conf.get_list(f"satellites.{sat}.chunks"),
             conf.get_list(f"satellites.{sat}.shards"),
         ),
-    )
+        concurrent_downloads=conf.get_int("consumer.num_workers", 5),
+    ))
 
     log.info(f"sat consumer finished in {time.time() - prog_start!s}")
 

--- a/src/satellite_consumer/download_eumetsat.py
+++ b/src/satellite_consumer/download_eumetsat.py
@@ -1,5 +1,6 @@
 """Functions for interfacing with EUMETSAT's API and data."""
 
+import asyncio
 import datetime as dt
 import logging
 import os
@@ -7,7 +8,8 @@ import re
 import shutil
 import tempfile
 import time
-from collections.abc import Iterator
+from collections import deque
+from collections.abc import AsyncIterator, Iterator
 from typing import TYPE_CHECKING
 
 import eumdac.customisation
@@ -134,6 +136,59 @@ def download_raw(
 
     return downloaded_files
 
+async def buffered_download_stream(
+    products: Iterator["eumdac.product.Product"],
+    folder: str,
+    filter_regex: str,
+    max_concurrent: int = 5,
+) -> AsyncIterator[list[str]]:
+    """Yield downloaded files from a stream of products.
+
+    Maintains a buffer of concurrent downloads to ensure the next product is ready
+    as soon as the consumer is free.
+    """
+    # Create the task buffer
+    tasks: deque[asyncio.Task[list[str]]] = deque()
+
+    # Fill the initial buffer
+    for product in products:
+        if len(tasks) >= max_concurrent:
+            break
+        tasks.append(
+            asyncio.create_task(
+                asyncio.to_thread(
+                    download_raw,
+                    product=product,
+                    folder=folder,
+                    filter_regex=filter_regex,
+                ),
+            ),
+        )
+
+    # Yield results and replenish the buffer
+    while tasks:
+        # Wait for the *chronologically next* task to finish
+        # This preserves the order of the products stream
+        result = await tasks.popleft()
+        yield result
+
+        # Add the next product to the buffer (if any left)
+        try:
+             next_product = next(products)
+             tasks.append(
+                asyncio.create_task(
+                    asyncio.to_thread(
+                        download_raw,
+                        product=next_product,
+                        folder=folder,
+                        filter_regex=filter_regex,
+                    ),
+                ),
+            )
+        except StopIteration:
+            pass
+
+
 def download_customisation(
     customisation: eumdac.customisation.Customisation,
     folder: str,
@@ -212,4 +267,3 @@ def download_customisation(
                 )
 
     return downloaded_filepaths
-


### PR DESCRIPTION
## Description
This PR implements a "sliding window" pipeline to address **Issue #73**, replacing the previous batch-based approach with an asynchronous producer-consumer model. This allows data processing (CPU-bound) to occur concurrently with data downloading (I/O-bound), significantly improving throughput.

## Key Changes
- **[src/satellite_consumer/download_eumetsat.py](cci:7://file:///c:/Users/Anvay/Desktop/satellite-consumer/src/satellite_consumer/download_eumetsat.py:0:0-0:0)**:
    - Introduced [buffered_download_stream](cci:1://file:///c:/Users/Anvay/Desktop/satellite-consumer/src/satellite_consumer/download_eumetsat.py:138:0-188:16): An async generator that manages a sliding window of concurrent download tasks.
    - Implemented a `deque`-based task buffer to ensuring that while downloads happen in parallel, results are yielded in strict **chronological order** to the consumer.

- **[src/satellite_consumer/consume.py](cci:7://file:///c:/Users/Anvay/Desktop/satellite-consumer/src/satellite_consumer/consume.py:0:0-0:0)**:
    - Refactored [consume_to_store](cci:1://file:///c:/Users/Anvay/Desktop/satellite-consumer/src/satellite_consumer/consume.py:29:0-135:95) to be `async`.
    - Replaced the synchronous loop with an `async for` loop over the buffered stream.
    - Wrapped the CPU-intensive `process_raw` function in `asyncio.to_thread` to prevent blocking the event loop (and thus the background downloads).
    - Integrated with the new upstream structure (using [consume.py](cci:7://file:///c:/Users/Anvay/Desktop/satellite-consumer/src/satellite_consumer/consume.py:0:0-0:0) instead of [run.py](cci:7://file:///c:/Users/Anvay/Desktop/satellite-consumer/src/satellite_consumer/run.py:0:0-0:0)).

- **[src/satellite_consumer/cmd/main.py](cci:7://file:///c:/Users/Anvay/Desktop/satellite-consumer/src/satellite_consumer/cmd/main.py:0:0-0:0)**:
    - Updated the entry point to execute the consumer using `asyncio.run()`.
    - Exposed `concurrent_downloads` configuration (defaulting to 5 workers).

## Verification
- [x] **Unit Tests**: Passed (`uv run python -m unittest discover ...`)
- [x] **Type Safety**: Passed `mypy` checks on all modified files.
- [x] **Linting**: Passed `ruff check`.
- [x] **Manual Verification**: Validated that logs show processing starting before downloads complete (e.g., `. . . . [Processing] num_files=1`).
