### PR TITLE
feat(core): Allow parallelisation to use threads or processes

### DIFF
--- a/src/satellite_consumer/cmd/application.conf
+++ b/src/satellite_consumer/cmd/application.conf
@@ -22,8 +22,18 @@ consumer {
     use_icechunk = ${?SATCONS_ICECHUNK}
     loglevel = "INFO"
     loglevel = ${?LOGLEVEL}
-    # Number of downloads to prefetch
-    buffer_size = 10
+    # Number of images to prefetch for writing
+    buffer_size = 3
+    buffer_size=${?SATCONS_BUFFER_SIZE}
+    # Size of worker pool
+    max_workers = 3
+    max_workers=${?SATCONS_MAX_WORKERS}
+    # Whether worker pool is "processes" or "threads"
+    executor = "threads"
+    executor=${?SATCONS_EXECUTOR}
+    # Number of images to accumulate before writing each block
+    accum_writes = 1
+    accum_writes=${?SATCONS_ACCUM_WRITES}
 }
 
 satellites {

--- a/src/satellite_consumer/cmd/main.py
+++ b/src/satellite_consumer/cmd/main.py
@@ -106,6 +106,9 @@ def main() -> None:
                 conf.get_list(f"satellites.{sat}.shards"),
             ),
             buffer_size=conf.get_int("consumer.buffer_size"),
+            max_workers=conf.get_int("consumer.max_workers"),
+            accum_writes=conf.get_int("consumer.accum_writes"),
+            executor=conf.get_string("consumer.executor"),
         ),
     )
 


### PR DESCRIPTION
### Changes in this Pull Request
This PR:

- Upgrades the `_buffered_apply()` function so it can use either threads or processes. The current version only allows threads to be used.

- Optionally, allows images to be accumulated and appended to the zarr as a blob. This is faster than appending each image as it is available but requires more RAM.

- Adds to the applications config so the length of the buffer, the number of workers, the pool type (threads/processes), and the number of images to accumulate can all be configured with env vars. I've set the defaults so that the sat-consumer will use less compute resources, but for max speed the user will want to change most of these. 

- Adds to the logging so that the % progress through the time period is logged

I did a speed test on this new version vs the current version on main and found a speed up of almost 3X. To download 6 hours worth of RSS imagery (so 72 images) the main branch took 170-180s and this branch took 60-70s. On this branch I used the settings:

```
SATCONS_BUFFER_SIZE=40 
SATCONS_MAX_WORKERS=10 
SATCONS_EXECUTOR="processes" 
SATCONS_ACCUM_WRITES=12
```


### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?
