### PR TITLE
Flush zip file before unpacking

### DIFF
--- a/src/satellite_consumer/download_eumetsat.py
+++ b/src/satellite_consumer/download_eumetsat.py
@@ -123,7 +123,11 @@ def download_raw(
                     tempfile.NamedTemporaryFile(dir=tmpdir, suffix=".zip") as fdst,
                 ):
                     shutil.copyfileobj(fsrc, fdst, length=1024 * 1024)
+
+                    # Make sure the file is flushed to disk before unzipping
+                    fdst.flush()
                     shutil.unpack_archive(fdst.name, tmpdir, "zip")
+
                     for file in product_files:
                         save_path: str = f"{save_folder}/{file}"
                         fs.put(f"{tmpdir}/{file}", save_path)


### PR DESCRIPTION
### Changes in this Pull Request

I've been getting persistent errors in my run of the docker container on a cloud VM like:

```
error downloading product Failed to download output 'MSG1-SEVI-MSG15-0100-NA-20100304121417.453000000Z-NA': '/home/raw/tmphsg_hp79/tmph8e4i9tl.zip is not a zip file'
```

This is due to the zip file not being pushed to disk before we try to unzip it. The way the code is now some or all of the file can still be in buffer. Adding `fdst.flush()` seems to have solved the issue.


### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?
