### PR TITLE
perf(storage): only open existing store once

### DIFF
--- a/src/satellite_consumer/test_storage.py
+++ b/src/satellite_consumer/test_storage.py
@@ -85,6 +85,7 @@ class TestStorage(unittest.TestCase):
                         dst=test["dst"],
                         append_dim="time",
                         encoding=encoding,
+                        write_new=True,
                     )
                     store_ds = xr.open_zarr(test["dst"], consolidated=False)
                     self.assertTrue((store_ds.data_vars["data"].isel(time=0).values == 1.0).all())


### PR DESCRIPTION
### Changes in this Pull Request

This PR changes how the dimension check is done. Previously we were opening the existing store inside `write_to_store()` and checking the incoming data to see if the dims matched. This meant that we opened the existing store afresh on each iteration of the write loop just to check the channel, and spatial coords.

This PR refactors this check so we only open the existing store once. The store, if it exists, is now only opened once inside `consume_to_store()` and we reuse it on each iteration of the write loop to check that the coords are as expected. If we are not writing to an already existing store, then we keep the first dataset returned in the loop and compare the coords of subsequent datasets to this first item.

This is more efficient and should speed up that loop.


### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?




