### PR TITLE
feat(consume): add option to continue store from last timestamp

### DIFF
--- a/src/satellite_consumer/cmd/application.conf
+++ b/src/satellite_consumer/cmd/application.conf
@@ -9,10 +9,10 @@ consumer {
     start_timestamp = ${?SATCONS_START_TIMESTAMP}
     end_timestamp = "2025-08-25T00:15:00Z"
     end_timestamp = ${?SATCONS_END_TIMESTAMP}
-    # If continue_store is set to true the consumer will modify the start_timestamp to the last
+    # If jump_to_latest is set to true the consumer will modify the start_timestamp to the last
     # timestamp available in the store
-    continue_store = false
-    continue_store = ${?SATCONS_CONTINUE}
+    jump_to_latest = true
+    jump_to_latest = ${?SATCONS_JUMP_TO_LATEST}
     # Parent folder to store downloaded and processed data in.
     # Can be either a local path or an S3 path (s3://bucket-name/prefix)
     # Ignored if SATCONS_RAW_PATH and SATCONS_ZARR_PATH are defined.

--- a/src/satellite_consumer/cmd/main.py
+++ b/src/satellite_consumer/cmd/main.py
@@ -106,7 +106,7 @@ def main() -> None:
             max_workers=conf.get_int("consumer.max_workers"),
             accum_writes=conf.get_int("consumer.accum_writes"),
             executor=conf.get_string("consumer.executor"),
-            continue_store=conf.get_bool("consumer.continue_store"),
+            jump_to_latest=conf.get_bool("consumer.jump_to_latest"),
         ),
     )
 


### PR DESCRIPTION
### Changes in this Pull Request

This PR adds a new environmental variable and option to continue a store from the last timestamp. The RSS zarrs could be up to 105k timestamps / year. This can mean when restarting zarr creation we may have to iterate through 10s of thousands of `eumdac` Products to find the first one which isn't in our store. This is slow for us and also puts unnecessary load on the Data Store service. 

The default of this flag is False so that extra images that might have failed on previous passes can be added to zarr. If set to true the download effectively resumes from where it stopped

### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?