### PR TITLE
perf(process): Nullify satpy `_add_scanline_acq_time()` method

### DIFF
--- a/src/satellite_consumer/process.py
+++ b/src/satellite_consumer/process.py
@@ -22,8 +22,12 @@ from satellite_consumer.exceptions import ValidationError
 log = logging.getLogger("sat_consumer")
 
 
-def _dummy_add_scanline_acq_time(*args: tuple[Any, ...], **kwargs: object) -> None:
-    """Dummy function to patch satpy v0.59.0 for speed.
+def _dummy_add_scanline_acq_time(
+    self: NativeMSGFileHandler,
+    *args: object,
+    **kwargs: object,
+) -> None:
+    """Dummy function to patch satpy for speed.
 
     The private `NativeMSGFileHandler._add_scanline_acq_time()` method takes about 1 second to run
     per image, and is run each time the `scene.load()` method is called. This method adds the
@@ -33,8 +37,11 @@ def _dummy_add_scanline_acq_time(*args: tuple[Any, ...], **kwargs: object) -> No
     """
     pass
 
+
 # Patch the method to nullify it
-NativeMSGFileHandler._add_scanline_acq_time = _dummy_add_scanline_acq_time
+NativeMSGFileHandler._add_scanline_acq_time = (  # type: ignore[method-assign]
+    _dummy_add_scanline_acq_time
+)
 
 
 def process_raw(


### PR DESCRIPTION
### Changes in this Pull Request

From profiling the satellite consumer I found that the satpy `_add_scanline_acq_time()` method takes up a significant fraction of the processing time for each image. From my testing each image takes 3-4s to process, and of that about 1s is spent on `_add_scanline_acq_time()`. This function is called whenever `Scene.load()` is called - though we have to follow the call-stack down quite far to it. 

This method only acts to create the `"acq_time"` variable in the datasets which we delete before saving anyway. This means that we can easily patch this method to nullify it and save that 1s/image. Since the method is self-contained, we can do this with pretty trivial code changes as in this PR which would be easy to revert in the future.

### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?




