### PR TITLE
chore(logs): Make debug logs more useful for monitoring consumer speed

### DIFF
--- a/src/satellite_consumer/consume.py
+++ b/src/satellite_consumer/consume.py
@@ -133,7 +133,7 @@ def _download_and_process(
 
         t_end = time.time()
         log.debug(
-            f"Downloaded ({t_dl-t_start:.2f}s) and processed ({t_end-t_dl:.2f}s)"
+            f"Downloaded ({t_dl - t_start:.2f}s) and processed ({t_end - t_dl:.2f}s)"
             f" for timestamp {np.datetime_as_string(ds.time.values[0], unit='s')}"
         )
 


### PR DESCRIPTION
### Changes in this Pull Request

This PR changes the debug logs to make them more useful for monitoring the downloading and processing time of the consumer. This should be useful to help users choose some settings like the timeout value and help us decide on where to focus future efforts for speed-ups. 

The main performance monitoring log added looks like:
```
2026-02-02 17:05:10 DEBUG    Downloaded (2.53s) and processed (3.09s) for timestamp 2023-01-01T00:05:00
```

and I've removed a couple of old log statements which now feel like clutter

### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

