### PR TITLE
chore(logging): Move logs to eumdac logger

### DIFF
--- a/src/satellite_consumer/request_patch.py
+++ b/src/satellite_consumer/request_patch.py
@@ -9,8 +9,8 @@ from collections.abc import Callable
 from typing import Literal
 
 import requests
-from eumdac.request import RequestError, _pretty_print, _should_retry
 from eumdac.logging import logger
+from eumdac.request import RequestError, _pretty_print, _should_retry
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 


### PR DESCRIPTION
### Changes in this Pull Request

Currently when setting the log level to DEBUG a lot of debug logs are printed from the patched request function. This PR moves these logs to the `eumdac` logger so that it is treated the same as `eumdac` logs and therefore the debug logs are filtered out

### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?



