### PR TITLE
fix(process): Handle corrupt satellite archive files

### DIFF
--- a/src/satellite_consumer/process.py
+++ b/src/satellite_consumer/process.py
@@ -84,7 +84,7 @@ def process_raw(
         )
 
     except ValueError as e:
-        # There seem to be corrupted (short) files in the EUMETSAT Data Store archive
+        # There seem to be corrupted (short) files in the EUMETSAT Data Store archive
         # Catch this error for the shorter than expected files
         if "buffer is smaller than requested size" in str(e):
             raise ValidationError(f"Truncated satellite file(s) {paths} detected: {e}") from e


### PR DESCRIPTION
### Changes in this Pull Request

I've seen this error raised for a few different timestamps

```
ValueError: buffer is smaller than requested size
```

This is raised from the `process_raw()` function when satpy tries to open the native file. I've tried downloading the same data multiple times and it does not appear to be due to the download being interrupted since it consistently happens on the same timestamps. When this happens the native files are smaller than usual on disk. However, for these small native files, they are the size which is stated in the manifest.xml file which comes in the downloaded zip file. This suggests they are corrupt in EUMETSAT's archive.

This PR adds an error handler for this to catch the `ValueError` and instead return a `ValidationError` so that this file is skipped.

### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?




