### PR TITLE
fix(consume): Jump to end of store

### DIFF
--- a/src/satellite_consumer/consume.py
+++ b/src/satellite_consumer/consume.py
@@ -239,7 +239,7 @@ async def consume_to_store(
         )
 
     # Optionally set the start datetime to the last datetime in the store
-    if jump_to_latest and store_ds is not None:
+    if jump_to_latest and (store_ds is not None) and (existing_times[-1] > dt_range[0]):
         start = existing_times[-1]
         log.info(f"skipping to end of store: {start}")
     else:


### PR DESCRIPTION
### Changes in this Pull Request

When `jump_to_latest` setting is used we start from the end of the existing store regardless of the datetime range requested.

This means that if the last timestamp in the store is before the start of the requested date-range, we will download images from before the requested range. 

To me it seems like the behaviour should be to start from the request start date, and only allow a forward skip (not a back skip).

This PR implements the change for this new behaviour


### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [ ] Have you successfully run `make test` with your changes locally?