### PR TITLE
fix(main): Correct ordering of AWS config input

### DIFF
--- a/src/satellite_consumer/cmd/main.py
+++ b/src/satellite_consumer/cmd/main.py
@@ -99,8 +99,8 @@ def main() -> None:
             aws_credentials=(
                 conf.get_string("credentials.aws.access_key_id", None),
                 conf.get_string("credentials.aws.secret_access_key", None),
-                conf.get_string("credentials.aws.endpoint_url", None),
                 conf.get_string("credentials.aws.region", None),
+                conf.get_string("credentials.aws.endpoint_url", None),
             ),
             gcs_credentials=conf.get_string("credentials.gcs.application_credentials", None),
             encoding=conf.get_config(f"satellites.{sat}.encoding"),


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

Fixes a bug in the main config.