### PR TITLE
fix(cmd): Be more explicit about timezones

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -34,5 +34,4 @@ jobs:
           GIT_API_TAGGING: false
           MAJOR_STRING_TOKEN: "BREAKING CHANGE"
           MINOR_STRING_TOKEN: "feat("
-          PATCH_STRING_TOKEN: "fix("
-          DEFAULT_BUMP: none
+          DEFAULT_BUMP: patch

--- a/src/satellite_consumer/cmd/main.py
+++ b/src/satellite_consumer/cmd/main.py
@@ -39,6 +39,13 @@ def main() -> None:
         dt.datetime.fromisoformat(conf.get_string("consumer.start_timestamp")),
         dt.datetime.fromisoformat(conf.get_string("consumer.end_timestamp")),
     )
+    for ts in dt_range:
+        if ts.tzinfo is None:
+            raise ValueError(f"Input timestamp '{ts}' must be timezone-aware")
+    dt_range = (
+        dt_range[0].astimezone(tz=dt.UTC),
+        dt_range[1].astimezone(tz=dt.UTC),
+    )
 
     sensor: str = conf.get_string(f"satellites.{sat}.sensor")
     resolution: int = conf.get_int("consumer.resolution_meters")

--- a/src/satellite_consumer/consume.py
+++ b/src/satellite_consumer/consume.py
@@ -272,7 +272,7 @@ async def consume_to_store(
             pd.Timestamp(product.sensing_end)
             .round(f"{cadence_mins} min")
             .to_pydatetime()
-            .astimezone(tz=dt.UTC)
+            .replace(tzinfo=dt.UTC)  # EUMETSAT files are UTC without an explicit timezone
         )
         return rounded_time not in existing_times
 

--- a/uv.lock
+++ b/uv.lock
@@ -2449,7 +2449,7 @@ wheels = [
 
 [[package]]
 name = "satellite-consumer"
-version = "0.9.0.post4+git.575dd87d.dirty"
+version = "1.0.1.post0+git.fa9ec129.dirty"
 source = { editable = "." }
 dependencies = [
     { name = "asyncio" },


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/satellite-consumer/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/satellite-consumer/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

Corrects an issue in the conversion of the sensing time from eumetsat where times were interpreted as local instead of UTC.